### PR TITLE
fix: handle also state in verification request by returning it to the response_uri

### DIFF
--- a/wallet/openid4vp_qr_to_info.zen
+++ b/wallet/openid4vp_qr_to_info.zen
@@ -76,6 +76,12 @@ When I create size of 'matching_credentials'
 When I create the 'string array' named 'vps'
 When I pickup a 'string' from path 'jwt.payload.dcql_query.credentials.1.claims'
 
+# state?
+When I pickup from path 'jwt.payload'
+If I verify 'state' is found in 'payload'
+    When I pickup from path 'payload.state'
+EndIf
+
 ## ldp_vc
 When I set 'ldp_vc_string' to 'ldp_vc' as 'string'
 If I verify 'format' is equal to 'ldp_vc_string'
@@ -255,6 +261,9 @@ If I verify 'format' is equal to 'dc+sd-jwt_string'
             When I move named by 'id' in 'vp_token'
             When I create the 'string dictionary' named 'presentation'
             When I move 'vp_token' in 'presentation'
+            If I verify 'state' is found
+                When I copy 'state' in 'presentation'
+            EndIf
             When I move 'presentation' in 'loop_vps_card'
             When I move 'loop_vps_card' in 'vps'
             When I remove 'id'

--- a/wallet/openid4vp_response.zen
+++ b/wallet/openid4vp_response.zen
@@ -2,12 +2,17 @@ Rule unknown ignore
 
 Scenario 'http': params
 
-Given I have a 'string dictionary' in path 'body.vp_token'
+Given I have a 'string dictionary' named 'body'
 Given I have a 'string' named 'url'
 
 When I create 'string dictionary' named 'body_params'
+When I pickup from path 'body.vp_token'
 When I create json escaped string of 'vp_token'
 When I move 'json escaped string' to 'vp_token' in 'body_params'
+If I verify 'state' is found in 'body'
+    When I pickup from path 'body.state'
+    When I move 'state' in 'body_params'
+EndIf
 When I create http get parameters from 'body_params' using percent encoding
 
 Then print the 'http get parameters'


### PR DESCRIPTION
afaik state is used without holder binding, but the openid conformance checks also for holder binding, not sure but at least we return it if it was present in input
